### PR TITLE
Make the version matching regex and min/max version constants public.

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -10,20 +10,12 @@ module Semantic
     class ValidationFailure < ArgumentError; end
 
     class << self
-      LOOSE_REGEX = /
-        \A
-        (\d+)[.](\d+)[.](\d+) # Major . Minor . Patch
-        (?: [-](.*?))?        # Prerelease
-        (?: [+](.*?))?        # Build
-        \Z
-      /x
-
       # Parse a Semantic Version string.
       #
       # @param ver [String] the version string to parse
       # @return [Version] a comparable {Version} object
       def parse(ver)
-        match, major, minor, patch, prerelease, build = *ver.match(LOOSE_REGEX)
+        match, major, minor, patch, prerelease, build = *ver.match(/\A#{REGEX_FULL}\Z/)
 
         if match.nil?
           raise 'Version numbers MUST begin with three dot-separated numbers'
@@ -164,5 +156,19 @@ module Semantic
     def first_prerelease
       self.class.new(@major, @minor, @patch, [])
     end
+
+    public
+
+    # Version string matching regexes
+    REGEX_NUMERIC = "(\\d+)[.](\\d+)[.](\\d+)" # Major . Minor . Patch
+    REGEX_PRE     = "(?:[-](.*?))?"            # Prerelease
+    REGEX_BUILD   = "(?:[+](.*?))?"            # Build
+    REGEX_FULL    = REGEX_NUMERIC + REGEX_PRE + REGEX_BUILD
+
+    # The lowest precedence Version possible
+    MIN = self.new(0, 0, 0, []).freeze
+
+    # The highest precedence Version possible
+    MAX = self.new((1.0/0.0), 0, 0).freeze
   end
 end

--- a/lib/semantic/version_range.rb
+++ b/lib/semantic/version_range.rb
@@ -123,7 +123,7 @@ module Semantic
           start = process_loose_expr(expr).last.send(:first_prerelease)
         end
 
-        self.new(start, MAX_VERSION)
+        self.new(start, Semantic::Version::MAX)
       end
 
       # Returns a range covering all versions greater than or equal to the given
@@ -139,7 +139,7 @@ module Semantic
           start = process_loose_expr(expr).first.send(:first_prerelease)
         end
 
-        self.new(start, MAX_VERSION)
+        self.new(start, Semantic::Version::MAX)
       end
 
       # Returns a range covering all versions less than the given `expr`.
@@ -154,7 +154,7 @@ module Semantic
           finish = process_loose_expr(expr).first.send(:first_prerelease)
         end
 
-        self.new(MIN_VERSION, finish, true)
+        self.new(Semantic::Version::MIN, finish, true)
       end
 
       # Returns a range covering all versions less than or equal to the given
@@ -166,10 +166,10 @@ module Semantic
       def parse_lte_expression(expr)
         if expr =~ /^[^+]*-/
           finish = Version.parse(expr)
-          self.new(MIN_VERSION, finish)
+          self.new(Semantic::Version::MIN, finish)
         else
           finish = process_loose_expr(expr).last.send(:first_prerelease)
-          self.new(MIN_VERSION, finish, true)
+          self.new(Semantic::Version::MIN, finish, true)
         end
       end
 
@@ -323,12 +323,6 @@ module Semantic
 
     private
 
-    # The lowest precedence Version possible
-    MIN_VERSION = Version.new(0, 0, 0, []).freeze
-
-    # The highest precedence Version possible
-    MAX_VERSION = Version.new((1.0/0.0), 0, 0).freeze
-
     # Determines whether this {VersionRange} has an earlier endpoint than the
     # give `other` range.
     #
@@ -342,13 +336,13 @@ module Semantic
     # Describes whether this range has an upper limit.
     # @return [Boolean] true if this range has no upper limit
     def open_end?
-      self.end == MAX_VERSION
+      self.end == Semantic::Version::MAX
     end
 
     # Describes whether this range has a lower limit.
     # @return [Boolean] true if this range has no lower limit
     def open_begin?
-      self.begin == MIN_VERSION
+      self.begin == Semantic::Version::MIN
     end
 
     # Describes whether this range follows the patterns for matching all


### PR DESCRIPTION
Thomas' SemVer collation key extension needed access to the min and max versions and Semantic::Version seemed like the most logical place for them to live.

Having the matching regex strings available externally simplifies things like making route recognition consistent with the actual version strings that are allowed. It's not the end of the world though if there is a good reason to keep those private.
