### PR TITLE
(task) Rename library to publish as gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased][unreleased]
+### Changed
+
+## 0.0.1 - 2015-03-20
+### Added

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-Semantic
-========
+SemanticPuppet
+==============
+
+Library of useful tools for working with Semantic Versions and module
+dependencies.
+
+Description
+-----------
+
+Library of tools used by Puppet to parse, validate, and compare Semantic
+Versions and Version Ranges and to query and resolve module dependencies.
+
+For sparse, but accurate documentation, please see the docs directory.
+
+Note that this is a 0 release version, and things can change. Expect that the
+version and version range code to stay relatively stable, but the module
+dependency code is expected to change.
+
+This library is used by a number of Puppet Labs projects, including
+[Puppet](https://github.com/puppetlabs/puppet) and
+[r10k](https://github.com/puppetlabs/r10k).
+
+Requirements
+------------
+
+Semantic_puppet will work on several ruby versions, including 1.9.3, 2.0.0, and
+2.1.0. Ruby 1.8.7 is immediately deprecated as it is in
+[r10k](https://github.com/puppetlabs/r10k).
+
+No gem/library requirements.
+
+Installation
+------------
+
+### Rubygems
+
+For general use, you should install semantic_puppet from Ruby gems:
+
+    gem install semantic_puppet
+
+### Github
+
+If you have more specific needs or plan on modifying semantic_puppet you can
+install it out of a git repository:
+
+    git clone git://github.com/puppetlabs/semantic_puppet
+
+Usage
+-----
+
+SemanticPuppet is intended to be used as a library. 
+
+### Verison Range Operator Support
+
+SemanticPuppet will support the same version range operators as those used when
+publishing modules to [Puppet Forge](https://forge.puppetlabs.com) which is
+documented at 
+[Publishing Modules on the Puppet Forge](https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#dependencies-in-metadatajson).
+
+Contributors
+------------
+
+Pieter van de Bruggen wrote the library originally, with additions by Alex
+Dreyer, Jesse Scott and Anderson Mills.

--- a/lib/semantic.rb
+++ b/lib/semantic.rb
@@ -1,7 +1,0 @@
-module Semantic
-  autoload :Version, 'semantic/version'
-  autoload :VersionRange, 'semantic/version_range'
-  autoload :Dependency, 'semantic/dependency'
-
-  VERSION = '0.0.1'
-end

--- a/lib/semantic_puppet.rb
+++ b/lib/semantic_puppet.rb
@@ -1,0 +1,7 @@
+module SemanticPuppet
+  autoload :Version, 'semantic_puppet/version'
+  autoload :VersionRange, 'semantic_puppet/version_range'
+  autoload :Dependency, 'semantic_puppet/dependency'
+
+  VERSION = '0.1.0'
+end

--- a/lib/semantic_puppet/dependency.rb
+++ b/lib/semantic_puppet/dependency.rb
@@ -1,15 +1,15 @@
-require 'semantic'
+require 'semantic_puppet'
 
-module Semantic
+module SemanticPuppet
   module Dependency
     extend self
 
-    autoload :Graph,         'semantic/dependency/graph'
-    autoload :GraphNode,     'semantic/dependency/graph_node'
-    autoload :ModuleRelease, 'semantic/dependency/module_release'
-    autoload :Source,        'semantic/dependency/source'
+    autoload :Graph,         'semantic_puppet/dependency/graph'
+    autoload :GraphNode,     'semantic_puppet/dependency/graph_node'
+    autoload :ModuleRelease, 'semantic_puppet/dependency/module_release'
+    autoload :Source,        'semantic_puppet/dependency/source'
 
-    autoload :UnsatisfiableGraph, 'semantic/dependency/unsatisfiable_graph'
+    autoload :UnsatisfiableGraph, 'semantic_puppet/dependency/unsatisfiable_graph'
 
     # @!group Sources
 

--- a/lib/semantic_puppet/dependency/graph.rb
+++ b/lib/semantic_puppet/dependency/graph.rb
@@ -1,6 +1,6 @@
-require 'semantic/dependency'
+require 'semantic_puppet/dependency'
 
-module Semantic
+module SemanticPuppet
   module Dependency
     class Graph
       include GraphNode

--- a/lib/semantic_puppet/dependency/graph_node.rb
+++ b/lib/semantic_puppet/dependency/graph_node.rb
@@ -1,7 +1,7 @@
-require 'semantic/dependency'
+require 'semantic_puppet/dependency'
 require 'set'
 
-module Semantic
+module SemanticPuppet
   module Dependency
     module GraphNode
       include Comparable

--- a/lib/semantic_puppet/dependency/module_release.rb
+++ b/lib/semantic_puppet/dependency/module_release.rb
@@ -1,6 +1,6 @@
-require 'semantic/dependency'
+require 'semantic_puppet/dependency'
 
-module Semantic
+module SemanticPuppet
   module Dependency
     class ModuleRelease
       include GraphNode
@@ -9,10 +9,10 @@ module Semantic
 
       # Create a new instance of a module release.
       #
-      # @param source [Semantic::Dependency::Source]
+      # @param source [SemanticPuppet::Dependency::Source]
       # @param name [String]
-      # @param version [Semantic::Version]
-      # @param dependencies [{String => Semantic::VersionRange}]
+      # @param version [SemanticPuppet::Version]
+      # @param dependencies [{String => SemanticPuppet::VersionRange}]
       def initialize(source, name, version, dependencies = {})
         @source      = source
         @name        = name.freeze

--- a/lib/semantic_puppet/dependency/source.rb
+++ b/lib/semantic_puppet/dependency/source.rb
@@ -1,6 +1,6 @@
-require 'semantic/dependency'
+require 'semantic_puppet/dependency'
 
-module Semantic
+module SemanticPuppet
   module Dependency
     class Source
       def self.priority

--- a/lib/semantic_puppet/dependency/unsatisfiable_graph.rb
+++ b/lib/semantic_puppet/dependency/unsatisfiable_graph.rb
@@ -1,6 +1,6 @@
-require 'semantic/dependency'
+require 'semantic_puppet/dependency'
 
-module Semantic
+module SemanticPuppet
   module Dependency
     class UnsatisfiableGraph < StandardError
       attr_reader :graph

--- a/lib/semantic_puppet/version.rb
+++ b/lib/semantic_puppet/version.rb
@@ -1,8 +1,8 @@
-require 'semantic'
+require 'semantic_puppet'
 
-module Semantic
+module SemanticPuppet
 
-  # @note Semantic::Version subclasses Numeric so that it has sane Range
+  # @note SemanticPuppet::Version subclasses Numeric so that it has sane Range
   #       semantics in Ruby 1.9+.
   class Version < Numeric
     include Comparable

--- a/lib/semantic_puppet/version_range.rb
+++ b/lib/semantic_puppet/version_range.rb
@@ -1,6 +1,6 @@
-require 'semantic'
+require 'semantic_puppet'
 
-module Semantic
+module SemanticPuppet
   class VersionRange < Range
     class << self
       # Parses a version range string into a comparable {VersionRange} instance.
@@ -123,7 +123,7 @@ module Semantic
           start = process_loose_expr(expr).last.send(:first_prerelease)
         end
 
-        self.new(start, Semantic::Version::MAX)
+        self.new(start, SemanticPuppet::Version::MAX)
       end
 
       # Returns a range covering all versions greater than or equal to the given
@@ -139,7 +139,7 @@ module Semantic
           start = process_loose_expr(expr).first.send(:first_prerelease)
         end
 
-        self.new(start, Semantic::Version::MAX)
+        self.new(start, SemanticPuppet::Version::MAX)
       end
 
       # Returns a range covering all versions less than the given `expr`.
@@ -154,7 +154,7 @@ module Semantic
           finish = process_loose_expr(expr).first.send(:first_prerelease)
         end
 
-        self.new(Semantic::Version::MIN, finish, true)
+        self.new(SemanticPuppet::Version::MIN, finish, true)
       end
 
       # Returns a range covering all versions less than or equal to the given
@@ -166,10 +166,10 @@ module Semantic
       def parse_lte_expression(expr)
         if expr =~ /^[^+]*-/
           finish = Version.parse(expr)
-          self.new(Semantic::Version::MIN, finish)
+          self.new(SemanticPuppet::Version::MIN, finish)
         else
           finish = process_loose_expr(expr).last.send(:first_prerelease)
-          self.new(Semantic::Version::MIN, finish, true)
+          self.new(SemanticPuppet::Version::MIN, finish, true)
         end
       end
 
@@ -340,13 +340,13 @@ module Semantic
     # Describes whether this range has an upper limit.
     # @return [Boolean] true if this range has no upper limit
     def open_end?
-      self.end == Semantic::Version::MAX
+      self.end == SemanticPuppet::Version::MAX
     end
 
     # Describes whether this range has a lower limit.
     # @return [Boolean] true if this range has no lower limit
     def open_begin?
-      self.begin == Semantic::Version::MIN
+      self.begin == SemanticPuppet::Version::MIN
     end
 
     # Describes whether this range follows the patterns for matching all

--- a/semantic_puppet.gemspec
+++ b/semantic_puppet.gemspec
@@ -1,16 +1,16 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "semantic"
+require "semantic_puppet"
 
 spec = Gem::Specification.new do |s|
   # Metadata
-  s.name        = "semantic"
-  s.version     = Semantic::VERSION
-  s.authors     = ["Pieter van de Bruggen"]
-  s.email       = ["pieter@puppetlabs.com"]
-  s.homepage    = "https://github.com/puppetlabs/semantic-gem"
+  s.name        = "semantic_puppet"
+  s.version     = SemanticPuppet::VERSION
+  s.authors     = ["Puppet Labs"]
+  s.email       = ["info@puppetlabs.com"]
+  s.homepage    = "https://github.com/puppetlabs/semantic_puppet-gem"
   s.summary     = "Useful tools for working with Semantic Versions."
-  # s.description = %q{TODO: Write a gem description}
+  s.description = %q{Tools used by Puppet to parse, validate, and compare Semantic Versions and Version Ranges and to query and resolve module dependencies.}
 
   # Manifest
   s.files         = `git ls-files`.split("\n")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,6 @@ RSpec.configure do |config|
   config.order = 'random'
 
   config.before do
-    Semantic::Dependency.instance_variable_set(:@sources, nil)
+    SemanticPuppet::Dependency.instance_variable_set(:@sources, nil)
   end
 end

--- a/spec/unit/semantic/dependency/source_spec.rb
+++ b/spec/unit/semantic/dependency/source_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-require 'semantic/dependency/source'
-
-describe Semantic::Dependency::Source do
-end

--- a/spec/unit/semantic_puppet/dependency/graph_node_spec.rb
+++ b/spec/unit/semantic_puppet/dependency/graph_node_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
-require 'semantic/dependency/graph_node'
+require 'semantic_puppet/dependency/graph_node'
 
-describe Semantic::Dependency::GraphNode do
+describe SemanticPuppet::Dependency::GraphNode do
   let(:klass) do
     Class.new do
-      include Semantic::Dependency::GraphNode
+      include SemanticPuppet::Dependency::GraphNode
 
       attr_accessor :name
 

--- a/spec/unit/semantic_puppet/dependency/graph_spec.rb
+++ b/spec/unit/semantic_puppet/dependency/graph_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
-require 'semantic/dependency/graph'
+require 'semantic_puppet/dependency/graph'
 
-describe Semantic::Dependency::Graph do
-  Graph         = Semantic::Dependency::Graph
-  GraphNode     = Semantic::Dependency::GraphNode
-  ModuleRelease = Semantic::Dependency::ModuleRelease
-  Version       = Semantic::Version
-  VersionRange  = Semantic::VersionRange
+describe SemanticPuppet::Dependency::Graph do
+  Graph         = SemanticPuppet::Dependency::Graph
+  GraphNode     = SemanticPuppet::Dependency::GraphNode
+  ModuleRelease = SemanticPuppet::Dependency::ModuleRelease
+  Version       = SemanticPuppet::Version
+  VersionRange  = SemanticPuppet::VersionRange
 
   describe '#initialize' do
     it 'can be called without arguments' do

--- a/spec/unit/semantic_puppet/dependency/module_release_spec.rb
+++ b/spec/unit/semantic_puppet/dependency/module_release_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'semantic/dependency/module_release'
+require 'semantic_puppet/dependency/module_release'
 
-describe Semantic::Dependency::ModuleRelease do
+describe SemanticPuppet::Dependency::ModuleRelease do
   def source
-    @source ||= Semantic::Dependency::Source.new
+    @source ||= SemanticPuppet::Dependency::Source.new
   end
 
   def make_release(name, version, deps = {})

--- a/spec/unit/semantic_puppet/dependency/source_spec.rb
+++ b/spec/unit/semantic_puppet/dependency/source_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+require 'semantic_puppet/dependency/source'
+
+describe SemanticPuppet::Dependency::Source do
+end

--- a/spec/unit/semantic_puppet/dependency/unsatisfiable_graph_spec.rb
+++ b/spec/unit/semantic_puppet/dependency/unsatisfiable_graph_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'semantic/dependency/unsatisfiable_graph'
+require 'semantic_puppet/dependency/unsatisfiable_graph'
 
-describe Semantic::Dependency::UnsatisfiableGraph do
+describe SemanticPuppet::Dependency::UnsatisfiableGraph do
 
   let(:modules) { %w[ foo bar baz ] }
   let(:graph) { double('Graph', :modules => modules) }

--- a/spec/unit/semantic_puppet/version_range_spec.rb
+++ b/spec/unit/semantic_puppet/version_range_spec.rb
@@ -1,39 +1,39 @@
 require 'spec_helper'
-require 'semantic/version'
+require 'semantic_puppet/version'
 
-describe Semantic::VersionRange do
+describe SemanticPuppet::VersionRange do
 
   describe '.parse' do
     def self.test_range(range_list, str, includes, excludes)
       Array(range_list).each do |expr|
         example "#{expr.inspect} stringifies as #{str}" do
-          range = Semantic::VersionRange.parse(expr)
+          range = SemanticPuppet::VersionRange.parse(expr)
           expect(range.to_s).to eql str
         end
 
         includes.each do |vstring|
           example "#{expr.inspect} includes #{vstring}" do
-            range = Semantic::VersionRange.parse(expr)
-            expect(range).to include(Semantic::Version.parse(vstring))
+            range = SemanticPuppet::VersionRange.parse(expr)
+            expect(range).to include(SemanticPuppet::Version.parse(vstring))
           end
 
           example "parse(#{expr.inspect}).to_s includes #{vstring}" do
-            range = Semantic::VersionRange.parse(expr)
-            range = Semantic::VersionRange.parse(range.to_s)
-            expect(range).to include(Semantic::Version.parse(vstring))
+            range = SemanticPuppet::VersionRange.parse(expr)
+            range = SemanticPuppet::VersionRange.parse(range.to_s)
+            expect(range).to include(SemanticPuppet::Version.parse(vstring))
           end
         end
 
         excludes.each do |vstring|
           example "#{expr.inspect} excludes #{vstring}" do
-            range = Semantic::VersionRange.parse(expr)
-            expect(range).to_not include(Semantic::Version.parse(vstring))
+            range = SemanticPuppet::VersionRange.parse(expr)
+            expect(range).to_not include(SemanticPuppet::Version.parse(vstring))
           end
 
           example "parse(#{expr.inspect}).to_s excludes #{vstring}" do
-            range = Semantic::VersionRange.parse(expr)
-            range = Semantic::VersionRange.parse(range.to_s)
-            expect(range).to_not include(Semantic::Version.parse(vstring))
+            range = SemanticPuppet::VersionRange.parse(expr)
+            range = SemanticPuppet::VersionRange.parse(range.to_s)
+            expect(range).to_not include(SemanticPuppet::Version.parse(vstring))
           end
         end
       end
@@ -211,21 +211,21 @@ describe Semantic::VersionRange do
     context 'invalid expressions' do
       example 'raise an appropriate exception' do
         ex = [ ArgumentError, 'Unparsable version range: "invalid"' ]
-        expect { Semantic::VersionRange.parse('invalid') }.to raise_error(*ex)
+        expect { SemanticPuppet::VersionRange.parse('invalid') }.to raise_error(*ex)
       end
     end
   end
 
   describe '#intersection' do
     def self.v(num)
-      Semantic::Version.parse("#{num}.0.0")
+      SemanticPuppet::Version.parse("#{num}.0.0")
     end
 
     def self.range(x, y, ex = false)
-      Semantic::VersionRange.new(v(x), v(y), ex)
+      SemanticPuppet::VersionRange.new(v(x), v(y), ex)
     end
 
-    EMPTY_RANGE = Semantic::VersionRange::EMPTY_RANGE
+    EMPTY_RANGE = SemanticPuppet::VersionRange::EMPTY_RANGE
 
     tests = {
       # This falls entirely before the target range
@@ -299,7 +299,7 @@ describe Semantic::VersionRange do
     end
 
     it 'cannot intersect with non-VersionRanges' do
-      msg = "value must be a Semantic::VersionRange"
+      msg = "value must be a SemanticPuppet::VersionRange"
       expect { inclusive.intersection(1..2) }.to raise_error(msg)
     end
   end

--- a/spec/unit/semantic_puppet/version_spec.rb
+++ b/spec/unit/semantic_puppet/version_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
-require 'semantic/version'
+require 'semantic_puppet/version'
 
-describe Semantic::Version do
+describe SemanticPuppet::Version do
 
   def subject(str)
-    Semantic::Version.parse(str)
+    SemanticPuppet::Version.parse(str)
   end
 
   describe '.parse' do
@@ -388,7 +388,7 @@ describe Semantic::Version do
     # smoke tests.
 
     def subject(str)
-      Semantic::Version.valid?(str)
+      SemanticPuppet::Version.valid?(str)
     end
 
     it 'recognizes valid versions' do
@@ -405,7 +405,7 @@ describe Semantic::Version do
 
   describe '#<=>' do
     def parse(vstring)
-      Semantic::Version.parse(vstring)
+      SemanticPuppet::Version.parse(vstring)
     end
 
     context 'Spec v2.0.0' do


### PR DESCRIPTION
Before this commit, the library was known as semantic. After this
commit, the library will be known as semantic_puppet.
