### PR TITLE
(RK-64) Remove build metadata from the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased][unreleased]
+## [Unreleased version][Unreleased date]
 ### Changed
 
-## 0.0.1 - 2015-03-20
+## 0.1.0 - 2015-03-23
 ### Added
+- initial release in concert with current Puppet Module Tool v4.0.0 behavior

--- a/lib/semantic_puppet/version.rb
+++ b/lib/semantic_puppet/version.rb
@@ -22,7 +22,12 @@ module SemanticPuppet
         end
 
         prerelease = parse_prerelease(prerelease) if prerelease
-        build = parse_build_metadata(build) if build
+        # Build metadata is not yet supported in semantic_puppet, but we hope to.
+        # The following code prevents build metadata for now.
+        #build = parse_build_metadata(build) if build
+        if !build.nil?
+          raise "'#{ver}' MUST NOT include build identifiers"
+        end
 
         self.new(major.to_i, minor.to_i, patch.to_i, prerelease, build)
       end

--- a/spec/unit/semantic_puppet/version_spec.rb
+++ b/spec/unit/semantic_puppet/version_spec.rb
@@ -167,6 +167,14 @@ describe SemanticPuppet::Version do
       end
 
       context 'Section 10' do
+        # Build metadata is not yet in scope so
+        it 'rejects build identifiers' do
+          ver = '1.2.3+anything'
+          expect { subject(ver) }.to raise_error("'#{ver}' MUST NOT include build identifiers")
+        end
+      end
+
+      context 'Section 10', :pending => "build metadata is not yet in scope" do
         # Build metadata MAY be denoted by appending a plus sign and a series
         # of dot separated identifiers immediately following the patch or
         # pre-release version. Identifiers MUST comprise only ASCII
@@ -492,6 +500,7 @@ describe SemanticPuppet::Version do
           end
 
           example 'build metadata does not figure into precendence' do
+            pending 'build metadata is not yet in scope'
             a = parse('1.0.0-alpha+SHA1')
             b = parse('1.0.0-alpha+MD5')
             expect(a).to eql b
@@ -576,8 +585,13 @@ describe SemanticPuppet::Version do
         expect(subject('1.1.1').next(:major)).to eql(subject('2.0.0'))
       end
 
-      it 'removes any prerelease or build information' do
-        expect(subject('1.0.0-alpha+abc').next(:major)).to eql(subject('2.0.0'))
+      it 'removes any prerelease information' do
+        expect(subject('1.0.0-alpha').next(:major)).to eql(subject('2.0.0'))
+      end
+
+      it 'removes any build information' do
+        pending 'build metadata is not yet in scope'
+        expect(subject('1.0.0+abc').next(:major)).to eql(subject('2.0.0'))
       end
     end
 
@@ -596,8 +610,13 @@ describe SemanticPuppet::Version do
         expect(subject('1.1.1').next(:minor)).to eql(subject('1.2.0'))
       end
 
-      it 'removes any prerelease or build information' do
-        expect(subject('1.1.0-alpha+abc').next(:minor)).to eql(subject('1.2.0'))
+      it 'removes any prerelease information' do
+        expect(subject('1.1.0-alpha').next(:minor)).to eql(subject('1.2.0'))
+      end
+
+      it 'removes any build information' do
+        pending 'build metadata is not yet in scope'
+        expect(subject('1.1.0+abc').next(:minor)).to eql(subject('1.2.0'))
       end
     end
 
@@ -612,8 +631,13 @@ describe SemanticPuppet::Version do
         expect(v1).to_not eql(v2)
       end
 
-      it 'removes any prerelease or build information' do
-        expect(subject('1.0.0-alpha+abc').next(:patch)).to eql(subject('1.0.1'))
+      it 'removes any prerelease information' do
+        expect(subject('1.0.0-alpha').next(:patch)).to eql(subject('1.0.1'))
+      end
+
+      it 'removes any build information' do
+        pending 'build metadata is not yet in scope'
+        expect(subject('1.0.0+abc').next(:patch)).to eql(subject('1.0.1'))
       end
     end
   end


### PR DESCRIPTION
Before this commit, the library could use build metadata in the version numbers. After this commit, the build identifiers are not permitted in the version.

The reason for this is that using this gem with Puppet would allow puppet module generate to create versions with build identifiers. Those modules would then by backward incompatible for no other reason than the build metadata. Adding that breaking feature should be a choice.

Note: The code and tests have been left in, but disabled and commented, so that it can be added back in when Semantic Version v2.0.0 is adopted by PMT, R10K, and Forge at the same time.
