### PR TITLE
(PUP-6249) Implement Version#== and Version#eql?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .yardoc
 coverage
 doc
+.idea/
+/.project

--- a/lib/semantic_puppet/version.rb
+++ b/lib/semantic_puppet/version.rb
@@ -115,6 +115,16 @@ module SemanticPuppet
       return compare_prerelease(other)
     end
 
+    def eql?(other)
+      other.is_a?(Version) &&
+        @major.eql?(other.major) &&
+        @minor.eql?(other.minor) &&
+        @patch.eql?(other.patch) &&
+        @prerelease.eql?(other.instance_variable_get(:@prerelease)) &&
+        @build.eql?(other.instance_variable_get(:@build))
+    end
+    alias == eql?
+
     def to_s
       "#{major}.#{minor}.#{patch}" +
       (@prerelease.nil? || prerelease.empty? ? '' : "-" + prerelease) +

--- a/spec/unit/semantic_puppet/version_spec.rb
+++ b/spec/unit/semantic_puppet/version_spec.rb
@@ -411,6 +411,47 @@ describe SemanticPuppet::Version do
     end
   end
 
+  describe '#==' do
+    def parse(vstring)
+      SemanticPuppet::Version.parse(vstring)
+    end
+
+    it 'should yield true when comparing two equal instances' do
+      x = parse('1.2.3-alpha')
+      y = parse('1.2.3-alpha')
+      expect(x == y).to eql(true)
+    end
+
+    it 'should yield false when the major differs' do
+      x = parse('1.2.3-alpha')
+      y = parse('2.2.3-alpha')
+      expect(x == y).to eql(false)
+    end
+
+    it 'should yield false when the minor differs' do
+      x = parse('1.2.3-alpha')
+      y = parse('1.3.3-alpha')
+      expect(x == y).to eql(false)
+    end
+
+    it 'should yield false when the patch differs' do
+      x = parse('1.2.3-alpha')
+      y = parse('1.2.4-alpha')
+      expect(x == y).to eql(false)
+    end
+
+    it 'should yield false when the prerelease differs' do
+      x = parse('1.2.3-alpha')
+      y = parse('1.2.3-beta')
+      expect(x == y).to eql(false)
+    end
+
+    it 'should yield false when compared to something that is not a Version' do
+      x = parse('1.2.3-alpha')
+      expect(x == :undef).to eql(false)
+    end
+  end
+
   describe '#<=>' do
     def parse(vstring)
       SemanticPuppet::Version.parse(vstring)


### PR DESCRIPTION
This commit adds the Version#eql? method and an alias #==. The addition
is necessary when using Ruby >= 2.3.0 since the a call to #eql? or #==
otherwize ends up in #<=> which performs no type checking and hence
raises an error on expressions like version == :undef.