### PR TITLE
(PUP-6341) Implement ModuleRelease#== and ModuleRelease#eql?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.3 - 2016-05-24
+### Added
+- Typesafe implementation of ModuleRelease#eql? (and ModuleRelease#==). (PUP-6341)
+
 ## 0.1.2 - 2016-04-29
 ### Added
 - Typesafe implementation of Version#eql? (and Version#==). (PUP-6249)

--- a/lib/semantic_puppet.rb
+++ b/lib/semantic_puppet.rb
@@ -3,5 +3,5 @@ module SemanticPuppet
   autoload :VersionRange, 'semantic_puppet/version_range'
   autoload :Dependency, 'semantic_puppet/dependency'
 
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/lib/semantic_puppet/dependency/module_release.rb
+++ b/lib/semantic_puppet/dependency/module_release.rb
@@ -38,6 +38,18 @@ module SemanticPuppet
         return our_key <=> their_key
       end
 
+      def eql?(other)
+        other.is_a?(ModuleRelease) &&
+          @name.eql?(other.name) &&
+          @version.eql?(other.version) &&
+          dependencies.eql?(other.dependencies)
+      end
+      alias == eql?
+
+      def hash
+        @name.hash ^ @version.hash
+      end
+
       def to_s
         "#<#{self.class} #{name}@#{version}>"
       end

--- a/spec/unit/semantic_puppet/dependency/module_release_spec.rb
+++ b/spec/unit/semantic_puppet/dependency/module_release_spec.rb
@@ -84,6 +84,29 @@ describe SemanticPuppet::Dependency::ModuleRelease do
 
   end
 
+  describe '#==' do
+
+    it 'considers two equal releases to be equal' do
+      expect(make_release('foo', '1.0.0')).to eql(make_release('foo', '1.0.0'))
+    end
+
+    it 'considers two releases with different names to be different' do
+      expect(make_release('foo', '1.0.0')).not_to eql(make_release('bar', '1.0.0'))
+    end
+
+    it 'considers two releases with different versions to be different' do
+      expect(make_release('foo', '1.0.0')).not_to eql(make_release('foo', '1.0.1'))
+    end
+
+    it 'can compare a release with something that is not a release' do
+      expect { make_release('foo', '1.0.0') == 5 }.not_to raise_error
+    end
+
+    it 'considers a release differnt from something that is not a release' do
+      expect(make_release('foo', '1.0.0') == 5).to be_falsey
+    end
+  end
+
   describe '#satisfied?' do
 
     it 'returns true when there are no dependencies to satisfy' do

--- a/spec/unit/semantic_puppet/dependency/module_release_spec.rb
+++ b/spec/unit/semantic_puppet/dependency/module_release_spec.rb
@@ -102,8 +102,8 @@ describe SemanticPuppet::Dependency::ModuleRelease do
       expect { make_release('foo', '1.0.0') == 5 }.not_to raise_error
     end
 
-    it 'considers a release differnt from something that is not a release' do
-      expect(make_release('foo', '1.0.0') == 5).to be_falsey
+    it 'considers a release different from something that is not a release' do
+      expect(make_release('foo', '1.0.0') == 5).to be false
     end
   end
 


### PR DESCRIPTION
This commit adds the ModuleRelease#eql? method and an alias #==. The
addition is necessary when using Ruby >= 2.3.0 since the a call to #eql?
or #== otherwise ends up in #<=> which performs no type checking and
hence raises an error on expressions like mod_ref == nil.