### PR TITLE
spec: Use cover instead of include for RSpec 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+---
+language: ruby
+sudo: false
+
+rvm:
+  - 2.0.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
+
+before_install:
+  - 'gem install bundler'
+
+script:
+  - bundle install
+  - bundle update
+  - bundle exec rake spec

--- a/spec/unit/semantic_puppet/version_range_spec.rb
+++ b/spec/unit/semantic_puppet/version_range_spec.rb
@@ -14,26 +14,26 @@ describe SemanticPuppet::VersionRange do
         includes.each do |vstring|
           example "#{expr.inspect} includes #{vstring}" do
             range = SemanticPuppet::VersionRange.parse(expr)
-            expect(range).to include(SemanticPuppet::Version.parse(vstring))
+            expect(range).to cover(SemanticPuppet::Version.parse(vstring))
           end
 
           example "parse(#{expr.inspect}).to_s includes #{vstring}" do
             range = SemanticPuppet::VersionRange.parse(expr)
             range = SemanticPuppet::VersionRange.parse(range.to_s)
-            expect(range).to include(SemanticPuppet::Version.parse(vstring))
+            expect(range).to cover(SemanticPuppet::Version.parse(vstring))
           end
         end
 
         excludes.each do |vstring|
           example "#{expr.inspect} excludes #{vstring}" do
             range = SemanticPuppet::VersionRange.parse(expr)
-            expect(range).to_not include(SemanticPuppet::Version.parse(vstring))
+            expect(range).to_not cover(SemanticPuppet::Version.parse(vstring))
           end
 
           example "parse(#{expr.inspect}).to_s excludes #{vstring}" do
             range = SemanticPuppet::VersionRange.parse(expr)
             range = SemanticPuppet::VersionRange.parse(range.to_s)
-            expect(range).to_not include(SemanticPuppet::Version.parse(vstring))
+            expect(range).to_not cover(SemanticPuppet::Version.parse(vstring))
           end
         end
       end


### PR DESCRIPTION
fixes #11 

I also added a Travis definition, which should run fine:
https://travis-ci.org/lazyfrosch/semantic_puppet/builds/148030352

You should probably activate travis :wink: 