### PR TITLE
Fix gettext

### DIFF
--- a/lib/semantic_puppet.rb
+++ b/lib/semantic_puppet.rb
@@ -1,4 +1,4 @@
-require 'gettext-setup'
+require 'gettext-setup/gettext-setup'
 
 module SemanticPuppet
   GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))

--- a/semantic_puppet.gemspec
+++ b/semantic_puppet.gemspec
@@ -22,7 +22,7 @@ spec = Gem::Specification.new do |s|
   # Dependencies
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency "gettext-setup", ">= 0.3"
+  s.add_dependency "gettext-setup", ">= 0.19.0"
 
   s.add_development_dependency "json", "~> 1.8.3" if RUBY_VERSION < '2.0'
   s.add_development_dependency "rake"


### PR DESCRIPTION
The latest version got released today, 0.19.0. It changed the namespace
from 'gettext-setup' to 'gettext-setup/gettext_setup':
https://github.com/puppetlabs/gettext-setup-gem/blob/master/lib/gettext_setup.rb
https://rubygems.org/gems/gettext-setup