### PR TITLE
(GH-25) Fix prerelease validation regex

### DIFF
--- a/lib/semantic_puppet/version.rb
+++ b/lib/semantic_puppet/version.rb
@@ -30,7 +30,7 @@ module SemanticPuppet
         false
       else
         prerelease = match[4]
-        prerelease.nil? || prerelease.split('.').all? { |x| !(x =~ /^0\d+/) }
+        prerelease.nil? || prerelease.split('.').all? { |x| !(x =~ /^0\d+$/) }
       end
     end
 


### PR DESCRIPTION
Before commit 4ced1fa the parse method used to call the valid? method
however after that commit, this was no longer true.  This meant the valid?
method no longer had any meaningful tests.  This commit copies the test cases
from parse to valid? to ensure no regressions occur.

This commit also adds an additional tests cases for the version numbers like
'2.1.0-0016-13fae4a9' which are commonly created by CI tools (build number +
commit SHA).

Previously the prerelease validation would check for leading zeros however it
would give false negatives if the leading zero was followed by alpha characters
e.g. 00abc.  This commit modifies the regualr expression to only apply the
leading zero check to all numeric portions and also check for invalid characters
fcbcfa9