### PR TITLE
(MAINT) Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @puppetlabs/forge-team @puppetlabs/platform-core

--- a/README.md
+++ b/README.md
@@ -62,10 +62,5 @@ for a list of contributors.
 
 ## Maintenance
 
-Maintainers:
-
-* Jesse Scott, jesse@puppet.com
-* Anderson Mills, anderson@puppet.com
-
 Tickets: File at
 [https://tickets.puppet.com/browse/FORGE](https://tickets.puppet.com/browse/FORGE)


### PR DESCRIPTION
@puppetlabs/platform-core Jesse and I were thinking your team is a sensible addition (along with the forge-team) to the CODEOWNERS file given that this is a [dependency of the puppet gem](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/pops.rb#L23). Let us know if you have any questions / concerns.