### PR TITLE
Add Ruby 2.7 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ notifications:
 sudo: false
 
 rvm:
+  - 2.7.0
   - "2.4.1"
   - "2.1.9"
   - "2.0.0"


### PR DESCRIPTION
More and more distributions ship Ruby 2.7 and also a bundled version of
the semantic_puppet gem. To ensure this work we should test against that
on Travis.