### PR TITLE
Clear sources prior to adding in tests

### DIFF
--- a/spec/unit/semantic_puppet/dependency_spec.rb
+++ b/spec/unit/semantic_puppet/dependency_spec.rb
@@ -42,7 +42,10 @@ describe SemanticPuppet::Dependency do
     context 'with one source' do
       let(:source) { double('Source', :priority => 0) }
 
-      before { SemanticPuppet::Dependency.add_source(source) }
+      before do
+        SemanticPuppet::Dependency.clear_sources
+        SemanticPuppet::Dependency.add_source(source)
+      end
 
       it 'queries the source for release information' do
         expect(source).to receive(:fetch).with('module_name').and_return([])


### PR DESCRIPTION
Since SemanticPuppet::Dependency has a global list of sources, it should be ensured that only the source under test is present. This can best be done by clearing the sources prior to adding one. Otherwise the test may leak between executions.