### PR TITLE
Fix unsatisfiable if resolve() fails

### DIFF
--- a/lib/semantic_puppet/dependency.rb
+++ b/lib/semantic_puppet/dependency.rb
@@ -73,7 +73,7 @@ module SemanticPuppet
     # @param graph [Graph] the root of a dependency graph
     # @return [Array<ModuleRelease>] the list of releases to act on
     def resolve(graph)
-      @module_dependencies, @satisfieds = nil
+      @module_dependencies = @satisfieds = nil
 
       catch :next do
         return walk(graph, graph.dependencies.dup)

--- a/lib/semantic_puppet/dependency.rb
+++ b/lib/semantic_puppet/dependency.rb
@@ -120,6 +120,8 @@ module SemanticPuppet
       name = dependencies.keys.sort.first
       deps = dependencies.delete(name)
 
+      @module_dependencies |= [name]
+
       # ... (and stepping over it if we've seen it before) ...
       unless (deps & considering).empty?
         return walk(graph, dependencies, *considering)
@@ -127,8 +129,6 @@ module SemanticPuppet
 
       # ... we'll iterate through the list of possible versions in order.
       preferred_releases(deps).reverse_each do |dep|
-        @module_dependencies |= [name]
-
         # We should skip any releases that violate any module's constraints.
         unless [graph, *considering].all? { |x| x.satisfies_constraints?(dep) }
           next

--- a/spec/unit/semantic_puppet/dependency_spec.rb
+++ b/spec/unit/semantic_puppet/dependency_spec.rb
@@ -247,6 +247,16 @@ describe SemanticPuppet::Dependency do
           expect { foo('1.1.0') }.to raise_exception with_message
           expect { foo('1.1.0') }.to raise_exception /\bfoo\b/
         end
+
+        it 'sets unsatisfiable' do
+          add_source_modules('foo', %w[ 1.1.0 ], 'bar' => '1.x')
+          add_source_modules('bar', %w[ 0.0.1 0.1.0-a 0.1.0 ])
+
+          with_message = /Could not find satisfying releases/
+          expect { foo('1.1.0') }.to raise_exception with_message
+
+          expect(SemanticPuppet::Dependency.unsatisfiable).to eq('foo')
+        end
       end
     end
 


### PR DESCRIPTION
Prior to this the output of unsatisfiable was always nil. This means it's impossible to actually diagnose why a dependency graph was broken.