### PR TITLE
Drop unneeded json dependency

### DIFF
--- a/semantic_puppet.gemspec
+++ b/semantic_puppet.gemspec
@@ -22,7 +22,6 @@ spec = Gem::Specification.new do |s|
   # Dependencies
   s.required_ruby_version = '>= 2.7.0'
 
-  s.add_development_dependency "json", "~> 1.8.3" if RUBY_VERSION < '2.0'
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
 


### PR DESCRIPTION
This was only used on Ruby 1 and we don't support that anymore.