### PR TITLE
Fix method name typo

### DIFF
--- a/lib/semantic_puppet/version_range.rb
+++ b/lib/semantic_puppet/version_range.rb
@@ -398,8 +398,8 @@ module SemanticPuppet
 
       # Merge two ranges so that the result matches the intersection of all matching versions.
       #
-      # @param range [AbastractRange] the range to intersect with
-      # @return [AbastractRange,nil] the intersection between the ranges
+      # @param range [AbstractRange] the range to intersect with
+      # @return [AbstractRange,nil] the intersection between the ranges
       #
       # @api private
       def intersection(range)
@@ -474,7 +474,7 @@ module SemanticPuppet
             excl_end = other.exclude_end?
           else
             max = self.end
-            excl_end = exclude_end && other.exclude_end?
+            excl_end = exclude_end? && other.exclude_end?
           end
 
           MinMaxRange.create(excl_begin ? GtRange.new(min) : GtEqRange.new(min), excl_end ? LtRange.new(max) : LtEqRange.new(max))
@@ -499,7 +499,7 @@ module SemanticPuppet
       # Checks if this matcher accepts a prerelease with the same major, minor, patch triple as the given version. Only matchers
       # where this has been explicitly stated will respond `true` to this method
       #
-      # @return [Boolean] `true` if this matcher accepts a prerelase with the tuple from the given version
+      # @return [Boolean] `true` if this matcher accepts a prerelease with the tuple from the given version
       def test_prerelease?(_)
         false
       end

--- a/spec/unit/semantic_puppet/version_range_spec.rb
+++ b/spec/unit/semantic_puppet/version_range_spec.rb
@@ -270,6 +270,16 @@ describe SemanticPuppet::VersionRange do
           expect(range.exclude_end?).to be_nil
         end
       end
+
+      context 'prerelease' do
+        test_expressions(
+          [ '>=5.0.1-rc0' || '>=0.5.0' ] => {
+            :to_str   => '>=5.0.1-rc0',
+            :includes => ['5.0.1-rc0', '5.0.1'], # should include 1.0.0
+            :excludes => ['1.0.0', '5.0.0-rc0', '5.0.2-rc0']
+          }
+        )
+      end
     end
 
     context 'invalid expressions' do


### PR DESCRIPTION
Fix NoMethodError when using a union (||) of comparator sets. Add test to cover that case and update comments.

```
❯ cat test.rb 
require 'semantic_puppet'
range = SemanticPuppet::VersionRange.parse('>=1.0.0 || >=2.0.0-rc0')
puts range.include?(SemanticPuppet::Version.parse('1.0.0'))

❯ bundle exec ruby test.rb
Traceback (most recent call last):
	7: from test.rb:2:in `<main>'
	6: from /home/josh/work/semantic_puppet/lib/semantic_puppet/version_range.rb:70:in `parse'
	5: from /home/josh/work/semantic_puppet/lib/semantic_puppet/version_range.rb:70:in `new'
	4: from /home/josh/work/semantic_puppet/lib/semantic_puppet/version_range.rb:246:in `initialize'
	3: from /home/josh/work/semantic_puppet/lib/semantic_puppet/version_range.rb:246:in `reduce'
	2: from /home/josh/work/semantic_puppet/lib/semantic_puppet/version_range.rb:246:in `each'
	1: from /home/josh/work/semantic_puppet/lib/semantic_puppet/version_range.rb:247:in `block in initialize'
/home/josh/work/semantic_puppet/lib/semantic_puppet/version_range.rb:477:in `merge': undefined local variable or method `exclude_end' for #<SemanticPuppet::VersionRange::GtEqRange:0x000055b278bacbd0> (NameError)
Did you mean?  exclude_end?
               excl_end
```

Note SemanticPuppet incorrectly merges comparators sets with prerelease versions. So it should consider 1.0.0 to be included in the range, but it is not currently. See #55
