### PR TITLE
(maint) Actions and Mend housekeeping

### DIFF
--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -33,4 +33,7 @@ jobs:
           WS_USERKEY: ${{ secrets.MEND_TOKEN }}
           WS_PRODUCTNAME: Puppet Core
           WS_PROJECTNAME: ${{ github.event.repository.name }}
-
+          WS_INCLUDE: Gemfile.lock
+          WS_FILESYSTEMSCAN: false
+          WS_RESOLVEALLDEPENDENCIES: false
+          WS_RUBY_RESOLVEDEPENDENCIES: true

--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -19,7 +19,7 @@ jobs:
           bundler-cache: true
       - name: Create lock
         run: bundle lock
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -15,12 +15,14 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {os: ubuntu-22.04, ruby: '3.1'}
-          - {os: ubuntu-22.04, ruby: '3.2'}
-          - {os: ubuntu-22.04, ruby: '3.3'}
-          - {os: ubuntu-22.04, ruby: '3.4'}
-          - {os: ubuntu-22.04, ruby: '4.0'}
-          - {os: ubuntu-22.04, ruby: 'jruby-9.4.8.0'}
+          - {os: ubuntu-latest, ruby: '3.1'}
+          - {os: ubuntu-latest, ruby: '3.2'}
+          - {os: ubuntu-latest, ruby: '3.3'}
+          - {os: ubuntu-latest, ruby: '3.4'}
+          - {os: ubuntu-latest, ruby: '4.0'}
+          - {os: ubuntu-latest, ruby: 'jruby-9.4.12.1'}
+          - {os: ubuntu-latest, ruby: 'jruby-10.0.5.0'}
+          - {os: ubuntu-latest, ruby: 'jruby-10.1.0.0'}
           - {os: windows-2022, ruby: '3.1'}
           - {os: windows-2022, ruby: '3.2'}
           - {os: windows-2022, ruby: '3.3'}

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   rspec_tests:
     name: ${{ matrix.cfg.os }}(ruby ${{ matrix.cfg.ruby }})
+    env:
+      BUNDLE_WITH: 'development'
     strategy:
       matrix:
         cfg:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,15 @@
 source "https://rubygems.org"
 
 gemspec
+
+group(:development, optional: true) do
+  gem 'rake'
+  gem 'rspec'
+
+  unless RUBY_PLATFORM =~ /java/
+    gem 'simplecov'
+    gem 'cane'
+    gem 'yard'
+    gem 'redcarpet'
+  end
+end

--- a/semantic_puppet.gemspec
+++ b/semantic_puppet.gemspec
@@ -21,14 +21,4 @@ spec = Gem::Specification.new do |s|
 
   # Dependencies
   s.required_ruby_version = '>= 2.7.0'
-
-  s.add_development_dependency "rake"
-  s.add_development_dependency "rspec"
-
-  unless RUBY_PLATFORM =~ /java/
-    s.add_development_dependency "simplecov"
-    s.add_development_dependency "cane"
-    s.add_development_dependency "yard"
-    s.add_development_dependency "redcarpet"
-  end
 end


### PR DESCRIPTION
Mend was flagging a version of JQuery shipped with the Yard gem as vulnerable. This PR moves development gems out of the gemspec into the Gemfile and marks them as optional. Additionally, it updates our Mend Workflow to only scan gem dependencies.

This PR also cleans up our GitHub Workflows to move away from older JRubies, GitHub Actions runner images, and Actions (Java).